### PR TITLE
Update eval_pkg.pkb.sql

### DIFF
--- a/product/sert/sert_core/package_body/eval_pkg.pkb.sql
+++ b/product/sert/sert_core/package_body/eval_pkg.pkb.sql
@@ -408,7 +408,7 @@ where
   || e.column_name     || ':'
   || e.shared_comp_name
   -- and er.current_value != e.current_value
-  and sert_core.sert_util.compare_string_yn(e.current_value,er.current_value) = 'Y'
+  and sert_core.sert_util.compare_string_yn(e.current_value,er.current_value) = 'N'
   and er.eval_id = p_eval_id
   );
 


### PR DESCRIPTION
Bug:
exceptions were being marked stale when they should not. compare string function test line 411 should be = 'N'
